### PR TITLE
Revert "Add Talk to Claude"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,4 @@ import React from 'react';
 import { render } from 'ink';
 import App from './ui/App.js';
 
-const allowTellClaudeSend = process.argv.includes('--danger-allow-send') || process.env.SAGE_ALLOW_SEND === '1';
-
-render(<App allowTellClaudeSend={allowTellClaudeSend} />);
+render(<App />);


### PR DESCRIPTION
Reverts usetig/sage#6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "Tell Claude" sending feature, its keybinding, and the --danger-allow-send/ENV gating, along with associated code and props.
> 
> - **UI (App)**:
>   - Remove `handleTellClaude`, `isSendingToClaude`, `claudeBinaryRef`, and related state/logic.
>   - Drop `T` keybinding and any references to telling Claude.
>   - Simplify `formatStatus` to exclude tell-Claude labels and flag.
>   - Remove unused imports (`execFile`, `promisify`) and `execFileAsync`.
> - **CLI/Entry**:
>   - Remove `--danger-allow-send` and `SAGE_ALLOW_SEND` handling; `App` no longer accepts `allowTellClaudeSend` prop and is rendered as `<App />`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d359ea9b5b4568eff92dfcf840e7c465234ae225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed the "Tell Claude" feature and associated keyboard shortcut functionality
  * Streamlined application initialization by eliminating feature flag configuration
  * Simplified keybinding system by removing conditional logic for optional features
  * Reduced overall complexity for improved code maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->